### PR TITLE
Update longest_dictionary_word_test.go

### DIFF
--- a/strings/longest_dictionary_word_test.go
+++ b/strings/longest_dictionary_word_test.go
@@ -10,8 +10,8 @@ TestLongestDictionaryWordContainingKey tests solution(s) with the following sign
 Given a key as string, and a slice of strings containing a dictionary of words, return the longest
 word that contains all letters of the key.
 
-For example given "cat" and {"rectify", "race", "archeology", "racoon"}, it should return "archeology",
-because "archeology" is the longest word in the given set that contains "c","a",and "t".
+For example given "car" and {"rectify", "race", "archeology", "racoon"}, it should return "archeology",
+because "archeology" is the longest word in the given set that contains "c","a",and "r".
 */
 func TestLongestDictionaryWordContainingKey(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What is being changed?
The comment provided an incorrect example; if the example given was really "cat", no words would be given back, as not a single string would contain all the letters. Thus, the example in the comment was changed to use "car" as an example

## What are the advantages of this change over what exists?
A correct example is provided to people that are reading thru this resource.

## What are the downsides of this change?
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
